### PR TITLE
Update weather conditions for Whilom Catfish

### DIFF
--- a/Supplemental/FFXIV Data - Fishing.tsv
+++ b/Supplemental/FFXIV Data - Fishing.tsv
@@ -1183,7 +1183,7 @@ Functional Proto-hropken	Platinum Fish				Thunder						1	438
 Allagan Bladeshark	Platinum Fish			Clouds	Thunder							477
 Opabinia	Platinum Fish				Thunder	Functional Proto-hropken, 3						501
 The Hundred Throes												
-Whilom Catfish	Goblin Jig											321
+Whilom Catfish	Goblin Jig				Fog, Clouds, Dust Storms							321
 Pipira Pira	Goblin Jig				Dust Storms, Fog, Clouds							341
 Blueclaw Shrimp	Stonefly Nymph											
 Grass Carp	Bladed Steel Jig				Dust Storms, Clouds, Fog							340
@@ -1192,7 +1192,7 @@ Dravanian Smelt	Brute Leech											440
 River Shrimp	Brute Leech						Light					
 Scaleripper	Brute Leech				Dust Storms, Fog, Clouds							465
 Whilom River												
-Whilom Catfish	Goblin Jig											321
+Whilom Catfish	Goblin Jig				Fog, Clouds, Dust Storms							321
 Rock Mussel	Stonefly Nymph									1		333
 Pipira Pira	Goblin Jig				Dust Storms, Fog, Clouds							341
 Three-lip Carp												
@@ -1200,7 +1200,7 @@ Blueclaw Shrimp	Stonefly Nymph
 Dravanian Bass	Blueclaw Shrimp	0	6		Dust Storms, Clouds, Fog							361
 Twin-tongued Carp	Brute Leech	12	16	Clouds, Dust Storms	Clear Skies							480
 The Smoldering Wastes												
-Whilom Catfish	Goblin Jig											321
+Whilom Catfish	Goblin Jig				Fog, Clouds, Dust Storms							321
 Rock Mussel	Stonefly Nymph									1		333
 Blueclaw Shrimp	Stonefly Nymph											
 Three-lip Carp												


### PR DESCRIPTION
Per [Gamer Escape wiki](https://ffxiv.gamerescape.com/wiki/Whilom_Catfish) it appears that Whilom Catfish are only available during Dust Stoms, Clouds, and Fog weather. This is supported by [FFXIV Angler](http://ff14angler.com/fish/321).