### PR TITLE
Replace modboard url with universalis

### DIFF
--- a/Garland.Web/db/index.html
+++ b/Garland.Web/db/index.html
@@ -1147,7 +1147,7 @@
                                 </span>
                                 <input type="number" class="market-price" {{?it.marketPrice}}value="{{=it.marketPrice}}"{{?}}>
 
-                                <a href="https://mogboard.com/market/{{=it.id}}" class="right">Open mogboard.</a>
+                                <a href="https://universalis.app/market/{{=it.id}}" class="right">Open Universalis.</a>
                             </div>
                         </div>
                     {{?}}


### PR DESCRIPTION
Mogboard data is neigh useless these days when compared to alternative solutions on the same framework, replacing the website will mean that players will have some kind of use out of this hyperlink