### PR TITLE
Encode characters for RFC3986 in gamer escape URLs

### DIFF
--- a/Garland.Web/db/index.html
+++ b/Garland.Web/db/index.html
@@ -254,7 +254,7 @@
                     <div>{{=it.name}} <span class="right">{{=it.type}}#{{=it.id}}</span></div>
 
                     <div class="block-links">
-                        <a href="http://ffxiv.gamerescape.com/wiki/{{=it.name}}" target="_blank">Open on Gamer Escape</a>.
+                        <a href="http://ffxiv.gamerescape.com/wiki/{{=it.name.replace("?", '').replace(/[!'()*]/g, escape)}}" target="_blank">Open on Gamer Escape</a>.
                     </div>
 
                     <hr>


### PR DESCRIPTION
I was getting pretty tired of seeing these and I finally noticed what's causing them.
![23-03-28_04-02-21-Veteran's_Clan_Mark_Log_-_Gamer_Escape's_Final_Fan](https://user-images.githubusercontent.com/12771982/228018172-15d6b2f4-246f-45db-965c-705adaa56029.png)

Due to a software limitation, I've also gone ahead and removed question marks from these too.
A little more as an example here
https://www.garlandtools.org/db/#item/33847
https://ffxiv.gamerescape.com/wiki/What_Is_Love_Orchestrion_Roll